### PR TITLE
added json format to Webhooks methods and fixed Webhook model

### DIFF
--- a/EmmaSharp/Methods/Webhooks.cs
+++ b/EmmaSharp/Methods/Webhooks.cs
@@ -1,6 +1,7 @@
 ﻿using EmmaSharp.Models.Webhooks;
 using RestSharp;
 using System.Collections.Generic;
+using RestSharp.Serializers;
 
 namespace EmmaSharp
 {
@@ -55,6 +56,8 @@ namespace EmmaSharp
         {
             var request = new RestRequest(Method.POST);
             request.Resource = "/{accountId}/webhooks";
+            request.RequestFormat = DataFormat.Json;
+            request.JsonSerializer = new EmmaJsonSerializer();
             request.AddBody(webhook);
 
             return Execute<int>(request);
@@ -71,6 +74,8 @@ namespace EmmaSharp
             var request = new RestRequest(Method.PUT);
             request.Resource = "/{accountId}/webhooks/{webhookId}";
             request.AddUrlSegment("webhookId", webhookId);
+            request.RequestFormat = DataFormat.Json;
+            request.JsonSerializer = new EmmaJsonSerializer();
             request.AddBody(webhook);
 
             return Execute<int>(request);

--- a/EmmaSharp/Models/Webhooks/Webhook.cs
+++ b/EmmaSharp/Models/Webhooks/Webhook.cs
@@ -13,10 +13,10 @@ namespace EmmaSharp.Models.Webhooks
         [JsonProperty("method")]
         public string Method { get; set; }
 
-        [JsonProperty("account_id")]
-        public int? AccountId { get; set; }
+        [JsonProperty("public_key")]
+        public string PublicKey { get; set; }
 
-        [JsonProperty("name")]
+        [JsonProperty("event")]
         public string Event { get; set; }
     }
 }


### PR DESCRIPTION
The POST and PUT requests for webhook updating need to be in Json format. Without this change, calls to these methods would return an HTTP Status Code of 400 of unrecognized JSON.
Replaced account id with public key and fixed json property name of the Event field in the Webhook model to match what the Emma API is actually expecting.