### PR TITLE
Made Status nullable

### DIFF
--- a/EmmaSharp/Models/Members/Import.cs
+++ b/EmmaSharp/Models/Members/Import.cs
@@ -13,7 +13,7 @@ namespace EmmaSharp.Models.Members
         public int? ImportId { get; set; }
 
         [JsonProperty("status")]
-        public Nullable<ImportStatus> Status { get; set; }
+        public ImportStatus? Status { get; set; }
 
         [JsonProperty("style")]
         public string Style { get; set; }

--- a/EmmaSharp/Models/Members/Import.cs
+++ b/EmmaSharp/Models/Members/Import.cs
@@ -13,7 +13,7 @@ namespace EmmaSharp.Models.Members
         public int? ImportId { get; set; }
 
         [JsonProperty("status")]
-        public ImportStatus Status { get; set; }
+        public Nullable<ImportStatus> Status { get; set; }
 
         [JsonProperty("style")]
         public string Style { get; set; }


### PR DESCRIPTION
Made Status nullable, otherwise a null value for "status" in the response from Emma will throw an exception. 

Calling GetImportInformation(importId) before the import is finished processing on Emma will result in a null status. When you push member data to Emma, the response is an importId. However, that doesn't mean the import is complete or is even valid. They stated in an email to me:

> Import data won't be immediately available. It takes time to process an import and the larger the import, the longer the wait. Depending on the other API traffic, that can add a slight delay as well. On average, a 50K import should be finished in under 5 minutes.

