### PR TITLE
Updated JSON property to correct value

### DIFF
--- a/EmmaSharp/Models/Members/UpdateMember.cs
+++ b/EmmaSharp/Models/Members/UpdateMember.cs
@@ -15,7 +15,7 @@ namespace EmmaSharp.Models.Members
         /// <summary>
         /// A new email address for the member.
         /// </summary>
-        [JsonProperty("member_email", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("email", NullValueHandling = NullValueHandling.Ignore)]
         public string MemberEmail { get; set; }
 
         /// <summary>


### PR DESCRIPTION
When updating a single member using Member ID (so you can update an email address for someone), the API is expecting "email" not "member_email". Successfully tested.