### PR TITLE
Add all emma subscriptions endpoints

### DIFF
--- a/EmmaSharp/EmmaSharp.csproj
+++ b/EmmaSharp/EmmaSharp.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Extensions\QueryFactory.cs" />
     <Compile Include="Extensions\StringEnumConverter.cs" />
     <Compile Include="Methods\Automation.cs" />
+    <Compile Include="Methods\Subscriptions.cs" />
     <Compile Include="Models\Automation\Workflow.cs" />
     <Compile Include="Models\Mailings\ForwardMailing.cs" />
     <Compile Include="Models\Mailings\MailingHeadsUp.cs" />

--- a/EmmaSharp/EmmaSharp.csproj
+++ b/EmmaSharp/EmmaSharp.csproj
@@ -118,6 +118,10 @@
     <Compile Include="Models\Searches\CreateSearch.cs" />
     <Compile Include="Models\Searches\Search.cs" />
     <Compile Include="Models\SignupForms\SignupForm.cs" />
+    <Compile Include="Models\Subscriptions\Subscription.cs" />
+    <Compile Include="Models\Subscriptions\SubscriptionBulk.cs" />
+    <Compile Include="Models\Subscriptions\SubscriptionMembers.cs" />
+    <Compile Include="Models\Subscriptions\SubscriptionNew.cs" />
     <Compile Include="Models\Triggers\Trigger.cs" />
     <Compile Include="Models\Webhooks\Webhook.cs" />
     <Compile Include="Models\Webhooks\WebhookEvents.cs" />

--- a/EmmaSharp/EmmaSharp.csproj
+++ b/EmmaSharp/EmmaSharp.csproj
@@ -33,17 +33,16 @@
     <DocumentationFile>bin\Release\EmmaSharp.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -121,6 +120,7 @@
     <Compile Include="Models\SignupForms\SignupForm.cs" />
     <Compile Include="Models\Subscriptions\Subscription.cs" />
     <Compile Include="Models\Subscriptions\SubscriptionBulk.cs" />
+    <Compile Include="Models\Subscriptions\SubscriptionImportBulk.cs" />
     <Compile Include="Models\Subscriptions\SubscriptionMembers.cs" />
     <Compile Include="Models\Subscriptions\SubscriptionNew.cs" />
     <Compile Include="Models\Triggers\Trigger.cs" />

--- a/EmmaSharp/Methods/Subscriptions.cs
+++ b/EmmaSharp/Methods/Subscriptions.cs
@@ -36,7 +36,7 @@ namespace EmmaSharp
         /// </summary>
         /// <returns>	Information about a subscription.</returns>
         /// <param name="subscription_id">URL segment for the subscrition ID to query details on</param>
-        public Subscription GetAccountSubscritpion(string subscription_id)
+        public Subscription GetAccountSubscription(string subscription_id)
         {
             var request = new RestRequest();
             request.Resource = "/{accountId}/subscriptions/{subscriptionId}";
@@ -100,7 +100,7 @@ namespace EmmaSharp
         /// <returns>True if successful.</returns>
         /// <param name="memberIds">List of memberIDs</param>
         /// <param name="subscription_id">subscription id</param>
-        public bool PostBulkSubscrpitions(SubscriptionBulk memberIds, string subscription_id)
+        public bool PostBulkMemberSubscrpitions(SubscriptionBulk memberIds, string subscription_id)
         {
             var request = new RestRequest(Method.POST);
             request.Resource = "/{accountId}/subscriptions/{subscriptionId}/members/bulk";
@@ -117,7 +117,7 @@ namespace EmmaSharp
         /// <summary>
         /// Edit a subscription's name or description.
         /// </summary>
-        /// <returns>Information about the updated subscription.</returns>
+        /// <returns>Information about the updated subscription.Limited to name and description.</returns>
         /// <param name="subscription">Name and descrpition of the subscription text to update. Visible in the Subscription Center.</param>
         /// <param name="subscription_id ">the id to update</param>
         public Subscription EditSubscrpition(SubscriptionNew subscription, string subscription_id)
@@ -138,7 +138,7 @@ namespace EmmaSharp
         /// </summary>
         /// <returns>Information about the subscription, including the date and time it was deleted.</returns>
         /// <param name="subscription_id ">the id to update</param>
-        public Subscription DeleteSubscrpition(string subscription_id)
+        public Subscription DeleteSubscription(string subscription_id)
         {
             var request = new RestRequest(Method.DELETE);
             request.Resource = "/{accountId}/subscriptions/{subscriptionId}";

--- a/EmmaSharp/Methods/Subscriptions.cs
+++ b/EmmaSharp/Methods/Subscriptions.cs
@@ -1,0 +1,153 @@
+﻿using EmmaSharp.Models.Subscriptions;
+using RestSharp;
+using RestSharp.Serializers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmmaSharp
+{
+    public partial class EmmaApi
+    {
+
+        /// <summary>
+        /// Get a list of all subscriptions in an account.
+        /// </summary>
+        /// <returns>A list of subscriptions in an account along with related information, including member count and subscription ID.</returns>
+        /// <param name="deletedOnly">true or false. Returns deleted subscriptions only. Optional, defaults to false.</param>
+        /// <param name="includeDeleted">true or false. Returns deleted subscriptions along with active. Optional, defaults to false./param>
+        public List<Subscription> GetAccountSubscritpions(bool deletedOnly = false, bool includeDeleted = false)
+        {
+            var request = new RestRequest();
+            request.Resource = "/{accountId}/subscriptions";
+
+            if (deletedOnly)
+                request.AddParameter("deleted_only", deletedOnly);
+            if (includeDeleted)
+                request.AddParameter("include_deleted", includeDeleted);
+
+            return Execute<List<Subscription>>(request);
+        }
+
+        /// <summary>
+        /// Get detailed information for a specific subscription.
+        /// </summary>
+        /// <returns>	Information about a subscription.</returns>
+        /// <param name="subscription_id">URL segment for the subscrition ID to query details on</param>
+        public Subscription GetAccountSubscritpion(string subscription_id)
+        {
+            var request = new RestRequest();
+            request.Resource = "/{accountId}/subscriptions/{subscriptionId}";
+            request.AddUrlSegment("subscriptionId", subscription_id);
+
+            return Execute<Subscription>(request);
+        }
+
+        /// <summary>
+        /// Get a list of member IDs for members subscribed to a specific subscription.
+        /// </summary>
+        /// <returns>	A list of member IDs.</returns>
+        /// <param name="subscription_id">URL segment for the subscrition ID to query details on</param>
+        /// <param name="start">Pagination: start page. Defaults to first page (e.g. 0).</param>
+        /// <param name="end">Pagination: end page. Defaults to first page (e.g. 500).</param>
+        public List<SubscriptionMembers> GetSubscriptionMembers(string subscription_id, int start = 0, int end = 500)
+        {
+            var request = new RestRequest();
+            request.Resource = "/{accountId}/subscriptions/{subscriptionId}/members";
+            request.AddUrlSegment("subscriptionId", subscription_id);
+
+            return Execute<List<SubscriptionMembers>>(request, start, end);
+        }
+
+        /// <summary>
+        /// Get a list of member IDs for members who have opted out of a specific subscription.
+        /// </summary>
+        /// <returns>	A list of member IDs.</returns>
+        /// <param name="subscription_id">URL segment for the subscrition ID to query details on</param>
+        /// <param name="start">Pagination: start page. Defaults to first page (e.g. 0).</param>
+        /// <param name="end">Pagination: end page. Defaults to first page (e.g. 500).</param>
+        public List<SubscriptionMembers> GetOptOutSubscriptionMembers(string subscription_id, int start = 0, int end = 500)
+        {
+            var request = new RestRequest();
+            request.Resource = "/{accountId}/subscriptions/{subscriptionId}/optouts";
+            request.AddUrlSegment("subscriptionId", subscription_id);
+
+            return Execute<List<SubscriptionMembers>>(request, start, end);
+        }
+
+        /// <summary>
+        /// Create a subscription
+        /// </summary>
+        /// <returns> Information about the created subscription, including the subscription ID.</returns>
+        /// <param name="subscription">Name and descrption of the new subcription to create</param>
+        public Subscription PostNewSubscription(SubscriptionNew subscription)
+        {
+            var request = new RestRequest(Method.POST);
+            request.Resource = "/{accountId}/subscriptions";
+
+            request.RequestFormat = DataFormat.Json;
+            request.JsonSerializer = new EmmaJsonSerializer();
+            request.AddBody(subscription);
+
+            return Execute<Subscription>(request);
+        }
+
+        /// <summary>
+        /// Bulk subscribe members to a subscription using a list of member IDs
+        /// </summary>
+        /// <returns>True if successful.</returns>
+        /// <param name="memberIds">List of memberIDs</param>
+        /// <param name="subscription_id">subscription id</param>
+        public bool PostBulkSubscrpitions(SubscriptionBulk memberIds, string subscription_id)
+        {
+            var request = new RestRequest(Method.POST);
+            request.Resource = "/{accountId}/subscriptions/{subscriptionId}/members/bulk";
+
+            request.AddUrlSegment("subscriptionId", subscription_id);
+            request.RequestFormat = DataFormat.Json;
+            request.JsonSerializer = new EmmaJsonSerializer();
+            request.AddBody(memberIds);
+
+            return Execute<bool>(request);
+        }
+
+
+        /// <summary>
+        /// Edit a subscription's name or description.
+        /// </summary>
+        /// <returns>Information about the updated subscription.</returns>
+        /// <param name="subscription">Name and descrpition of the subscription text to update. Visible in the Subscription Center.</param>
+        /// <param name="subscription_id ">the id to update</param>
+        public Subscription EditSubscrpition(SubscriptionNew subscription, string subscription_id)
+        {
+            var request = new RestRequest(Method.PUT);
+            request.Resource = "/{accountId}/subscriptions/{subscriptionId}";
+
+            request.AddUrlSegment("subscriptionId", subscription_id);
+            request.RequestFormat = DataFormat.Json;
+            request.JsonSerializer = new EmmaJsonSerializer();
+            request.AddBody(subscription);
+
+            return Execute<Subscription>(request);
+        }
+
+        /// <summary>
+        /// Delete a subscription.
+        /// </summary>
+        /// <returns>Information about the subscription, including the date and time it was deleted.</returns>
+        /// <param name="subscription_id ">the id to update</param>
+        public Subscription DeleteSubscrpition(string subscription_id)
+        {
+            var request = new RestRequest(Method.DELETE);
+            request.Resource = "/{accountId}/subscriptions/{subscriptionId}";
+
+            request.AddUrlSegment("subscriptionId", subscription_id);
+            request.RequestFormat = DataFormat.Json;
+            request.JsonSerializer = new EmmaJsonSerializer();           
+
+            return Execute<Subscription>(request);
+        }
+    }
+}

--- a/EmmaSharp/Methods/Subscriptions.cs
+++ b/EmmaSharp/Methods/Subscriptions.cs
@@ -17,7 +17,7 @@ namespace EmmaSharp
         /// </summary>
         /// <returns>A list of subscriptions in an account along with related information, including member count and subscription ID.</returns>
         /// <param name="deletedOnly">true or false. Returns deleted subscriptions only. Optional, defaults to false.</param>
-        /// <param name="includeDeleted">true or false. Returns deleted subscriptions along with active. Optional, defaults to false./param>
+        /// <param name="includeDeleted">true or false. Returns deleted subscriptions along with active. Optional, defaults to false.</param>
         public List<Subscription> GetAccountSubscritpions(bool deletedOnly = false, bool includeDeleted = false)
         {
             var request = new RestRequest();

--- a/EmmaSharp/Methods/Subscriptions.cs
+++ b/EmmaSharp/Methods/Subscriptions.cs
@@ -113,6 +113,25 @@ namespace EmmaSharp
             return Execute<bool>(request);
         }
 
+        /// <summary>
+        /// Bulk subscribe members to a subscription using the import ID of all members
+        /// </summary>
+        /// <returns>True if successful.</returns>
+        /// <param name="importId">import ID to bulk subscribe</param>
+        /// <param name="subscription_id">subscription id</param>
+        public bool PostBulkImportSubscrpitions(SubscriptionImportBulk importId, string subscription_id)
+        {
+            var request = new RestRequest(Method.POST);
+            request.Resource = "/{accountId}/subscriptions/{subscriptionId}/members/bulk";
+
+            request.AddUrlSegment("subscriptionId", subscription_id);
+            request.RequestFormat = DataFormat.Json;
+            request.JsonSerializer = new EmmaJsonSerializer();
+            request.AddBody(importId);
+
+            return Execute<bool>(request);
+        }
+
 
         /// <summary>
         /// Edit a subscription's name or description.

--- a/EmmaSharp/Models/Subscriptions/Subscription.cs
+++ b/EmmaSharp/Models/Subscriptions/Subscription.cs
@@ -1,0 +1,61 @@
+﻿using EmmaSharp.Extensions;
+using EmmaSharp.Models.Groups;
+using EmmaSharp.Models.Mailings;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace EmmaSharp.Models.Triggers
+{      
+
+    public class Subscription
+    {
+        [JsonProperty("account_id")]
+        public int AccountId { get; set; }
+
+        [JsonConverter(typeof(EmmaDateConverter))]
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonConverter(typeof(EmmaDateConverter))]
+        [JsonProperty("deleted_at")]
+        public DateTime? DeletedAt { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("import_status")]
+        public string ImportStatus { get; set; }
+
+        [JsonProperty("member_count")]
+        public int MemberCount { get; set; }
+
+        [JsonProperty("modified_at")]
+        public string ModifiedAt { get; set; }
+
+        [JsonProperty("optout_count")]
+        public int OptoutCount { get; set; }
+
+        [JsonConverter(typeof(EmmaDateConverter))]
+        [JsonProperty("purged_at")]
+        public DateTime? PurgedAt { get; set; }
+
+        [JsonProperty("settings")]
+        public Settings Settings { get; set; }
+
+        [JsonProperty("subscription_id")]
+        public int SubscriptionId { get; set; }
+
+        [JsonProperty("subscription_name")]
+        public string SubscriptionName { get; set; }
+
+        [JsonProperty("subscription_order")]
+        public int SubscriptionOrder { get; set; }
+    }
+    public class Settings
+    {
+        [JsonProperty("show_on_default_preference_form")]
+        public bool ShowOnDefaultPreferenceForm { get; set; }
+    }
+
+}

--- a/EmmaSharp/Models/Subscriptions/Subscription.cs
+++ b/EmmaSharp/Models/Subscriptions/Subscription.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
-namespace EmmaSharp.Models.Triggers
+namespace EmmaSharp.Models.Subscriptions
 {      
 
     public class Subscription

--- a/EmmaSharp/Models/Subscriptions/Subscription.cs
+++ b/EmmaSharp/Models/Subscriptions/Subscription.cs
@@ -11,7 +11,7 @@ namespace EmmaSharp.Models.Subscriptions
     public class Subscription
     {
         [JsonProperty("account_id")]
-        public int AccountId { get; set; }
+        public long? AccountId { get; set; }
 
         [JsonConverter(typeof(EmmaDateConverter))]
         [JsonProperty("created_at")]
@@ -28,13 +28,13 @@ namespace EmmaSharp.Models.Subscriptions
         public string ImportStatus { get; set; }
 
         [JsonProperty("member_count")]
-        public int MemberCount { get; set; }
+        public int? MemberCount { get; set; }
 
         [JsonProperty("modified_at")]
         public string ModifiedAt { get; set; }
 
         [JsonProperty("optout_count")]
-        public int OptoutCount { get; set; }
+        public int? OptoutCount { get; set; }
 
         [JsonConverter(typeof(EmmaDateConverter))]
         [JsonProperty("purged_at")]
@@ -44,13 +44,13 @@ namespace EmmaSharp.Models.Subscriptions
         public Settings Settings { get; set; }
 
         [JsonProperty("subscription_id")]
-        public int SubscriptionId { get; set; }
+        public long? SubscriptionId { get; set; }
 
         [JsonProperty("subscription_name")]
         public string SubscriptionName { get; set; }
 
         [JsonProperty("subscription_order")]
-        public int SubscriptionOrder { get; set; }
+        public int? SubscriptionOrder { get; set; }
     }
     public class Settings
     {

--- a/EmmaSharp/Models/Subscriptions/SubscriptionBulk.cs
+++ b/EmmaSharp/Models/Subscriptions/SubscriptionBulk.cs
@@ -10,6 +10,6 @@ namespace EmmaSharp.Models.Subscriptions
     public class SubscriptionBulk
     {
         [JsonProperty("member_ids")]
-        public List<int> MemberIds { get; set; }
+        public List<long> MemberIds { get; set; }
     }
 }

--- a/EmmaSharp/Models/Subscriptions/SubscriptionBulk.cs
+++ b/EmmaSharp/Models/Subscriptions/SubscriptionBulk.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmmaSharp.Models.Subscriptions
+{
+    public class SubscriptionBulk
+    {
+        [JsonProperty("member_ids")]
+        public List<int> MemberIds { get; set; }
+    }
+}

--- a/EmmaSharp/Models/Subscriptions/SubscriptionImportBulk.cs
+++ b/EmmaSharp/Models/Subscriptions/SubscriptionImportBulk.cs
@@ -7,11 +7,9 @@ using System.Threading.Tasks;
 
 namespace EmmaSharp.Models.Subscriptions
 {
-    public class SubscriptionBulk
+    public class SubscriptionImportBulk
     {
-        [JsonProperty("member_ids")]
-        public List<long> MemberIds { get; set; }
-
+        [JsonProperty("import_id")]
+        public long ImportId { get; set; }
     }
-
 }

--- a/EmmaSharp/Models/Subscriptions/SubscriptionMembers.cs
+++ b/EmmaSharp/Models/Subscriptions/SubscriptionMembers.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmmaSharp.Models.Subscriptions
+{
+    public class SubscriptionMembers
+    {
+        public List<Individual> MemberIds { get; set; }
+    }
+    public class Individual
+    {
+        [JsonProperty("member_id")]
+        public int MemberId { get; set; }
+    }
+}

--- a/EmmaSharp/Models/Subscriptions/SubscriptionMembers.cs
+++ b/EmmaSharp/Models/Subscriptions/SubscriptionMembers.cs
@@ -11,6 +11,6 @@ namespace EmmaSharp.Models.Subscriptions
     public class SubscriptionMembers
     {
         [JsonProperty("member_id")]
-        public int MemberId { get; set; }
+        public long MemberId { get; set; }
     }
 }

--- a/EmmaSharp/Models/Subscriptions/SubscriptionMembers.cs
+++ b/EmmaSharp/Models/Subscriptions/SubscriptionMembers.cs
@@ -7,11 +7,8 @@ using System.Threading.Tasks;
 
 namespace EmmaSharp.Models.Subscriptions
 {
+    
     public class SubscriptionMembers
-    {
-        public List<Individual> MemberIds { get; set; }
-    }
-    public class Individual
     {
         [JsonProperty("member_id")]
         public int MemberId { get; set; }

--- a/EmmaSharp/Models/Subscriptions/SubscriptionNew.cs
+++ b/EmmaSharp/Models/Subscriptions/SubscriptionNew.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmmaSharp.Models.Subscriptions
+{
+    
+    public class SubscriptionNew
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }
+}

--- a/EmmaSharp/packages.config
+++ b/EmmaSharp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net46" />
+  <package id="RestSharp" version="106.11.7" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Added all subscription endpoints and models. Tested each in our company's Emma environment. 
Usage is as follows:

Get Subscriptions:
` var getallsubs = emmasharp.GetAccountSubscritpions(); `

Get Subscription Details:
`var getasub = emmasharp.GetAccountSubscription("sub id");`

Get Members of a Subscription:
`var getmembersofasub = emmasharp.GetSubscriptionMembers("sub id");`

Get Opted-Out Members of a Subscription:
`var checkforoptout = emmasharp.GetOptOutSubscriptionMembers("sub id");`

Create a New Subscription Option:
` SubscriptionNew newSub = new SubscriptionNew
            {
                Name = "Test New API",
                Description = "This was programmatically added by the API"                
            }; `
`var postNewSub = emmasharp.PostNewSubscription(newSub);`

Subscribe Member IDs in Bulk:
`SubscriptionBulk memberIds = new SubscriptionBulk
            {
                MemberIds = new List<long> { memberid, memberid}
            };`

`var bulkmemmeers = emmasharp.PostBulkMemberSubscrpitions(memberIds, "sub id");`

Update Name or Description of an Existing Subscrpition:
`SubscriptionNew editSub = new SubscriptionNew{ Name = "Test New API - UPDATED",  Description = "This was programmatically added by the API - UPDATED" };`
`var editasub = emmasharp.EditSubscrpition(editSub, "sub id");`

Delete an Existing Subscrpition:
`var deleteasub = emmasharp.DeleteSubscrpition("sub id");`